### PR TITLE
Switch to the 47ng with force deployable option

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       # Deploy your application
-      - uses: rik/actions-clever-cloud@27db58285fce18efcca692b8a0ae70970898703e
+      - uses: 47ng/actions-clever-cloud@v1.2
         with:
           appID: app_62a6232b-6030-4ad4-a177-d24ff1f99d76
           force: true


### PR DESCRIPTION
Introduced with https://github.com/47ng/actions-clever-cloud/pull/188