### PR TITLE
Correction de openoffice en libreoffice

### DIFF
--- a/templates/tableau_upload.html
+++ b/templates/tableau_upload.html
@@ -10,9 +10,9 @@
         {% csrf_token %}
         <div class="fr-upload-group">
             <label class="fr-label" for="file-upload"
-            >Je souhaite visualiser le rendu final PDF d'un tableau réalisé avec OpenOffice :
+            >Je souhaite visualiser le rendu final PDF d'un tableau réalisé avec LibreOffice :
                 <ol>
-                    <li>Je travaille mon tableau sur OpenOffice</li>
+                    <li>Je travaille mon tableau sur LibreOffice</li>
                     <li>Avec la boite à outil "OutilNA", je fais un export XML</li>
                     <li>Je viens chercher le fichier XML avec le bouton "Parcourir" et je lance la génération de la visualisation PDF en appuyant sur le bouton "Générer le PDF"</li>
                 </ol>


### PR DESCRIPTION
Le logiciel utilisé pour l'édition des tableaux XML est libreoffice et non openoffice.