### PR TITLE
Disable Sentry tracing

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -151,10 +151,6 @@ BASICAUTH_USERS = {
 sentry_sdk.init(
     dsn=config("SENTRY_DSN"),
     integrations=[DjangoIntegration()],
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
     # If you wish to associate users to errors (assuming you are using
     # django.contrib.auth) you may enable sending PII data.
     send_default_pii=True,


### PR DESCRIPTION
We don't want to use it yet and it could consume our quota faster than intended.