### PR TITLE
CI require hashes and does not install unlisted dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev-requirements.txt
+          pip install --require-hashes --no-deps -r requirements.txt -r dev-requirements.txt
       - name: Run Tests
         run: |
           pytest unit_tests

--- a/.github/workflows/push_to_main.yml
+++ b/.github/workflows/push_to_main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev-requirements.txt
+          pip install --require-hashes --no-deps -r requirements.txt -r dev-requirements.txt
       - name: Run Tests
         run: |
           pytest unit_tests


### PR DESCRIPTION
This helps ensure that the requirements file we generate through pip-tools include hashes and include all possible dependencies of a package