### PR TITLE
Remove deprecated USE_L10N setting

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -116,8 +116,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.