### PR TITLE
Add log file available on ouvrage by date interface

### DIFF
--- a/home/ouvrages.py
+++ b/home/ouvrages.py
@@ -24,6 +24,7 @@ class Ouvrage(NamedTuple):
     document: OuvrageFile
     vignette: OuvrageFile | None = None
     metadata: OuvrageFile | None = None
+    log: OuvrageFile | None = None
 
     @classmethod
     def from_json(cls, name, json: dict):
@@ -32,6 +33,7 @@ class Ouvrage(NamedTuple):
 
         document = OuvrageFile.from_json("document.pdf", json["document.pdf"])
         vignette = OuvrageFile.from_json("vignette.jpg", json.get("vignette.jpg"))
+        log = OuvrageFile.from_json("stderr.log", json.get("stderr.log"))
         metadata_file_instances = [
             (x, y)
             for x, y in json.items()
@@ -43,7 +45,7 @@ class Ouvrage(NamedTuple):
             metadata = OuvrageFile.from_json(metadata_name, metadata_json)
         else:
             logging.warning("No metadata found for ouvrage named `%s`", name)
-        return cls(name, document, vignette, metadata)
+        return cls(name, document, vignette, metadata, log)
 
     @property
     def date(self):

--- a/static/css/sppnaut.css
+++ b/static/css/sppnaut.css
@@ -25,8 +25,8 @@
     max-height: 4rem;
 }
 
-.sppnaut-max-w-100w {
-    max-width: 50rem;
+.sppnaut-max-w-120w {
+    max-width: 60rem;
 }
 
 .sppnaut-overflow-y-auto {

--- a/templates/ouvrages_by_date.html
+++ b/templates/ouvrages_by_date.html
@@ -8,7 +8,7 @@
     <h1>Ouvrages en production (par date)</h1>
 
     {% for caption,ouvrages in ouvrages_by_date.items %}
-        {% include "partial/ouvrage_table.html" with allow_forced_generation=True %}
+        {% include "partial/ouvrage_table.html" with has_generation_access=True %}
     {% endfor %}
 
 

--- a/templates/ouvrages_by_name.html
+++ b/templates/ouvrages_by_name.html
@@ -6,5 +6,5 @@
 
 {% block content %}
     <h1>Ouvrages en production (par nom)</h1>
-    {% include "partial/ouvrage_table.html" with allow_forced_generation=False %}
+    {% include "partial/ouvrage_table.html" with has_generation_access=False %}
 {% endblock %}

--- a/templates/partial/ouvrage_table.html
+++ b/templates/partial/ouvrage_table.html
@@ -42,7 +42,7 @@
                         </td>
                         <td>
                             {% if ouvrage.log %}
-                                <a class='fr-link fr-btn--icon-left fr-icon-file-line' href="{{ouvrage.log.url}}" title="{{ ouvrage.log.name }}">
+                                <a class='fr-link' href="{{ouvrage.log.url}}" title="{{ ouvrage.log.name }}">
                                     Log
                                 </a>
                             {% endif %}

--- a/templates/partial/ouvrage_table.html
+++ b/templates/partial/ouvrage_table.html
@@ -1,4 +1,4 @@
-<div class="fr-table sppnaut-max-w-100w">
+<div class="fr-table sppnaut-max-w-120w">
     <table>
         <caption class='fr-mb-3w'>{{caption}}</caption>
         <tbody>
@@ -39,6 +39,13 @@
                                     Regénérer
                                 </button>
                             </form>
+                        </td>
+                        <td>
+                            {% if ouvrage.log %}
+                                <a class='fr-link fr-btn--icon-left fr-icon-file-line' href="{{ouvrage.log.url}}" title="{{ ouvrage.log.name }}">
+                                    Log
+                                </a>
+                            {% endif %}
                         </td>
                     {% endif %}
                 </tr>

--- a/templates/partial/ouvrage_table.html
+++ b/templates/partial/ouvrage_table.html
@@ -30,7 +30,14 @@
                             </a>
                         {% endif %}
                     </td>
-                    {% if allow_forced_generation %}
+                    {% if has_generation_access %}
+                        <td>
+                            {% if ouvrage.log %}
+                                <a class='fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line' href="{{ouvrage.log.url}}" title="{{ ouvrage.log.name }}">
+                                    Log
+                                </a>
+                            {% endif %}
+                        </td>
                         <td>
                             <form action="" method="POST" onsubmit="return confirm('Voulez-vous regénérer l\'ouvrage {{ ouvrage.name }} ?')">
                                 {% csrf_token %}
@@ -39,13 +46,6 @@
                                     Regénérer
                                 </button>
                             </form>
-                        </td>
-                        <td>
-                            {% if ouvrage.log %}
-                                <a class='fr-link' href="{{ouvrage.log.url}}" title="{{ ouvrage.log.name }}">
-                                    Log
-                                </a>
-                            {% endif %}
                         </td>
                     {% endif %}
                 </tr>

--- a/unit_tests/test_ouvrages.py
+++ b/unit_tests/test_ouvrages.py
@@ -19,7 +19,7 @@ class TestOuvrage:
             OuvrageFile("document.pdf", "http://fake.url", datetime.date(2022, 9, 16)),
         )
 
-    def test_document_pdf_with_vignette_and_metadata(self):
+    def test_document_pdf_with_vignette_and_metadata_and_log(self):
         ouvrage = Ouvrage.from_json(
             "103",
             {
@@ -34,6 +34,10 @@ class TestOuvrage:
                 "OUVNAUT_IN_G4.xml": {
                     "date": "2022-09-10T14:57:18.066Z",
                     "url": "http://fake_metadata.url",
+                },
+                "stderr.log": {
+                    "date": "2023-01-02T14:57:18.066Z",
+                    "url": "http://fake_log.url",
                 },
             },
         )
@@ -50,6 +54,11 @@ class TestOuvrage:
                 "OUVNAUT_IN_G4.xml",
                 "http://fake_metadata.url",
                 datetime.date(2022, 9, 10),
+            ),
+            OuvrageFile(
+                "stderr.log",
+                "http://fake_log.url",
+                datetime.date(2023, 1, 2),
             ),
         )
 
@@ -72,6 +81,10 @@ class TestOuvrage:
                 "OUVNAUT_IN_G4.yml": {
                     "date": "2022-09-10T14:57:18.066Z",
                     "url": "http://fake_metadata.url",
+                },
+                "document.log": {
+                    "date": "2023-01-02T14:57:18.066Z",
+                    "url": "http://fake_log.url",
                 },
             },
         )
@@ -119,6 +132,10 @@ class TestOuvrage:
                     "date": "2022-09-10T14:57:18.066Z",
                     "url": "http://fake_metadata.url",
                 },
+                "stderr.log": {
+                    "date": "2023-01-02T14:57:18.066Z",
+                    "url": "http://fake_log.url",
+                },
             },
         )
         assert not ouvrage
@@ -139,6 +156,10 @@ class TestOuvrage:
                     "date": "2022-09-10T14:57:18.066Z",
                     "url": "http://fake_metadata.url",
                 },
+                "stderr.log": {
+                    "date": "2023-01-02T14:57:18.066Z",
+                    "url": "http://fake_log.url",
+                },
             },
         )
 
@@ -150,6 +171,9 @@ class TestOuvrage:
         )
         assert ouvrage.vignette == OuvrageFile(
             "vignette.jpg", "http://fake_vignette.url", datetime.date(2022, 10, 22)
+        )
+        assert ouvrage.log == OuvrageFile(
+            "stderr.log", "http://fake_log.url", datetime.date(2023, 1, 2)
         )
 
     def test_files_one_document_pdf(self):

--- a/unit_tests/test_ouvrages.py
+++ b/unit_tests/test_ouvrages.py
@@ -19,49 +19,6 @@ class TestOuvrage:
             OuvrageFile("document.pdf", "http://fake.url", datetime.date(2022, 9, 16)),
         )
 
-    def test_document_pdf_with_vignette_and_metadata_and_log(self):
-        ouvrage = Ouvrage.from_json(
-            "103",
-            {
-                "document.pdf": {
-                    "date": "2022-09-16T14:57:18.066Z",
-                    "url": "http://fake.url",
-                },
-                "vignette.jpg": {
-                    "date": "2022-10-22T14:57:18.066Z",
-                    "url": "http://fake_vignette.url",
-                },
-                "OUVNAUT_IN_G4.xml": {
-                    "date": "2022-09-10T14:57:18.066Z",
-                    "url": "http://fake_metadata.url",
-                },
-                "stderr.log": {
-                    "date": "2023-01-02T14:57:18.066Z",
-                    "url": "http://fake_log.url",
-                },
-            },
-        )
-
-        assert ouvrage == Ouvrage(
-            "103",
-            OuvrageFile("document.pdf", "http://fake.url", datetime.date(2022, 9, 16)),
-            OuvrageFile(
-                "vignette.jpg",
-                "http://fake_vignette.url",
-                datetime.date(2022, 10, 22),
-            ),
-            OuvrageFile(
-                "OUVNAUT_IN_G4.xml",
-                "http://fake_metadata.url",
-                datetime.date(2022, 9, 10),
-            ),
-            OuvrageFile(
-                "stderr.log",
-                "http://fake_log.url",
-                datetime.date(2023, 1, 2),
-            ),
-        )
-
     def test_document_pdf_with_unknown_files(self):
         ouvrage = Ouvrage.from_json(
             "103",
@@ -91,7 +48,7 @@ class TestOuvrage:
         assert ouvrage == Ouvrage(
             "103",
             OuvrageFile("document.pdf", "http://fake.url", datetime.date(2022, 9, 16)),
-        ), "metadata and vignette should be named OUVNAUT*.xml and vignette.jpg"
+        ), "metadata, vignette and log should be named OUVNAUT*.xml, vignette.jpg and stderr.log"
 
     def test_document_pdf_with_2_metadata_files(self):
         ouvrage = Ouvrage.from_json(
@@ -163,6 +120,7 @@ class TestOuvrage:
             },
         )
 
+        assert ouvrage.name == "103"
         assert ouvrage.document == OuvrageFile(
             "document.pdf", "http://fake.url", datetime.date(2022, 9, 16)
         )


### PR DESCRIPTION
fix https://github.com/betagouv/SPPNaut/issues/138

We want to allow users to download the log of the last generation of the publication:

![image](https://user-images.githubusercontent.com/454431/210728741-6ef3d4ed-a348-4b19-8768-50c6ba29b857.png)

This feature would be used by NA-Prod and Sys-Prod Shom teams. Then we display such link only on ouvrage-by-date interface only (not in ouvrage-by-name)

This PR doesn't depend of PR on [SPPNaut](https://github.com/SPPNautOrga/SPPNaut/) because all files from generated production folder's bucket are returned when `document.pdf` exists 

To be discussed:
- [x] the link is display following `allow_forced_generation` flag : this flag is not well named for log availability
- [x] adding log in `Ouvrage` class didn't break the test
- [x] the table was enlarged to display the log link, however it enlarged the table also for ouvrage-by-name interface