### PR TITLE
Launch both development servers with one command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: PYTHONUNBUFFERED=True ./manage.py runserver 8000
+npm: npm run watch -- --port $PORT

--- a/README.md
+++ b/README.md
@@ -57,23 +57,15 @@ brew install gdal
 
     La base de données est composée des tables d'administration de django pour assurer l'authentification
 
-1. Lancement de django
-
-    `./manage.py runserver 0.0.0.0:8000`
-
-    L'interface est disponible sur votre navigateur à l'adresse [http://localhost:8000](http://localhost:8000)
-
 1. Installation des dépendances JS (Carting)
 
     `npm install`
 
-1. Lancement de parcel pour générer les bundle JS à la volée (Carting)
+1. Lancement des serveurs de développement
 
-    `npm run watch`
+    `honcho start`
 
-#### Note pour plus tard
-
-We have to run 2 servers on development env : parcel & python -> to investigate ([honcho](https://honcho.readthedocs.io/en/latest/index.html), makefile…)
+    L'interface est disponible sur votre navigateur à l'adresse [http://localhost:8000](http://localhost:8000)
 
 ### Ingestion du fichier document.xml d'un ouvrage en base de données (Carting)
 

--- a/core/filters.py
+++ b/core/filters.py
@@ -1,0 +1,6 @@
+from logging import Filter
+
+
+class SkipStaticFilter(Filter):
+    def filter(self, record):
+        return not record.getMessage().startswith('"GET /static/')

--- a/core/settings.py
+++ b/core/settings.py
@@ -135,16 +135,40 @@ SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", cast=bool)
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {
+    "filters": {
+        "skip_staticfiles": {
+            "()": "core.filters.SkipStaticFilter",
+        },
+    },
+    "formatters": {
         "console": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "{levelname}:{name}: {message}",
+            "style": "{",
+        },
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "{message}\n--------",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "django.server": {
             "class": "logging.StreamHandler",
+            "filters": ["skip_staticfiles"],
+            "formatter": "django.server",
         },
     },
     "root": {
-        "handlers": ["console"],
         "level": "WARNING",
     },
+    "loggers": {
+        "django.server": {
+            "handlers": ["django.server"],
+        }
+    },
 }
+
 
 GENERATOR_SERVICE_HOST = config("GENERATOR_SERVICE_HOST")
 GENERATOR_USERNAME = config("GENERATOR_USERNAME")

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,6 +1,7 @@
 --constraint=requirements.txt
 
 black
+honcho
 pytest
 pytest-django
 pytest-dotenv

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -55,6 +55,10 @@ exceptiongroup==1.1.0 \
     --hash=sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e \
     --hash=sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23
     # via pytest
+honcho==1.1.0 \
+    --hash=sha256:a4d6e3a88a7b51b66351ecfc6e9d79d8f4b87351db9ad7e923f5632cc498122f \
+    --hash=sha256:c5eca0bded4bef6697a23aec0422fd4f6508ea3581979a3485fc4b89357eb2a9
+    # via -r dev-requirements.in
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d


### PR DESCRIPTION
This is using [Honcho].

This is also filtering assets HTTP logging for a quieter output. This is convenient to help us see Parcel output within the combined Honcho output.

[Honcho]: https://honcho.readthedocs.io