### PR TITLE
Use the standalone VSCode Black formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,9 +4,10 @@
 
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
-        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
         "EditorConfig.EditorConfig",
-        "bradlc.vscode-tailwindcss"
+        "esbenp.prettier-vscode",
+        "ms-python.black-formatter"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
+    "python.formatting.provider": "none",
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
@@ -26,6 +26,9 @@
     },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
VSCode is splitting the Python extension into separate more focused extensions.