### PR TITLE
Use red for openlayers features in geometry field

### DIFF
--- a/carting/templates/admin/custom-openlayers.html
+++ b/carting/templates/admin/custom-openlayers.html
@@ -1,9 +1,28 @@
 {% extends "gis/openlayers-osm.html" %}
 
-{% block options %}{{ block.super }}
+{% block options %}
+{{ block.super }}
 options['map_epsg'] = '{{ map_epsg }}';
 options['dataset_epsg'] = '{{ dataset_epsg }}';
-{% endblock %}
+options["style"] = new ol.style.Style({
+    fill: new ol.style.Fill({ color: "rgba(255,0,0,.5)" }),
+    stroke: new ol.style.Stroke({
+        color: "red",
+        width: 2,
+    }),
+    image: new ol.style.Circle({
+        radius: 7,
+        fill: new ol.style.Fill({
+            color: "rgba(255, 0,0)",
+        }),
+        stroke: new ol.style.Stroke({
+            color: "white",
+            width: 2,
+        }),
+    }),
+})
+
+{% endblock options %}
 
 {% block base_layer %}
 const layerPerZoom = [

--- a/carting/widgets.py
+++ b/carting/widgets.py
@@ -2,6 +2,10 @@ from django.contrib.gis import forms
 
 
 class CustomOSMWidget(forms.widgets.BaseGeometryWidget):
+    # This widget is inspired from OSMWidget in django.contrib.gis.forms.widgets
+    # but the SRID manipulation in geodjango breaks our implementation because the
+    # raw coordinates displayed are in the wrong system, hence the partial rewrite
+    # instead of inheritance.
     template_name = "admin/custom-openlayers.html"
     default_lon = -2
     default_lat = 48.6
@@ -13,12 +17,12 @@ class CustomOSMWidget(forms.widgets.BaseGeometryWidget):
     class Media:
         css = {
             "all": (
-                "https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.css",
+                "https://cdn.jsdelivr.net/npm/ol@v7.2.2/ol.css",
                 "gis/css/ol3.css",
             )
         }
         js = (
-            "https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js",
+            "https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js",
             "admin-map-widget.js",
         )
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -53,9 +53,9 @@ click==8.1.3 \
     --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
     --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via black
-django==4.1.9 \
-    --hash=sha256:adae3a952fd86800094ae6f64aa558572e8b4ba8dfe21f0ed8175147e75a72a1 \
-    --hash=sha256:e9f074a84930662104871bfcea55c3c180c50a0a47739db82435deae6cbaf032
+django==4.2.2 \
+    --hash=sha256:2a6b6fbff5b59dd07bef10bcb019bee2ea97a30b2a656d51346596724324badf \
+    --hash=sha256:672b3fa81e1f853bb58be1b51754108ab4ffa12a77c06db86aa8df9ed0c46fe5
     # via
     #   django-browser-reload
     #   django-debug-toolbar
@@ -360,6 +360,10 @@ tomli==2.0.1 \
     # via
     #   black
     #   pytest
+typing-extensions==4.6.3 \
+    --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26 \
+    --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5
+    # via asgiref
 urllib3==1.26.14 \
     --hash=sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72 \
     --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "django-extensions==3.2.1",
     "django-nested-admin==4.0.2",
     "django-tree-queries==0.14.0",
-    "django==4.1.9",
+    "django==4.2.2",
     "lxml==4.9.2",
     "psycopg2==2.9.6",
     "python-decouple==3.8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ charset-normalizer==2.0.12 \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
     # via requests
-django==4.1.9 \
-    --hash=sha256:adae3a952fd86800094ae6f64aa558572e8b4ba8dfe21f0ed8175147e75a72a1 \
-    --hash=sha256:e9f074a84930662104871bfcea55c3c180c50a0a47739db82435deae6cbaf032
+django==4.2.2 \
+    --hash=sha256:2a6b6fbff5b59dd07bef10bcb019bee2ea97a30b2a656d51346596724324badf \
+    --hash=sha256:672b3fa81e1f853bb58be1b51754108ab4ffa12a77c06db86aa8df9ed0c46fe5
     # via
     #   django-extensions
     #   sppnaut (pyproject.toml)


### PR DESCRIPTION
* Upgrade to django 4.2.x to ease customization of OpenLayers code
* Add a custom style for features that are drawn in the map in geometry widgets
* Replace customized OpenLayers by its most recent version from Django and port required changes to display RasterMarine to django admin 