### PR TITLE
Fix STATICFILES_STORAGE deprecation warning

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -122,7 +122,11 @@ STATICFILES_DIRS = [
     BASE_DIR / "static" / "to_collect",
     BASE_DIR / "static" / "compiled",
 ]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    }
+}
 WHITENOISE_KEEP_ONLY_HASHED_FILES = True
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 DJANGO_SETTINGS_MODULE = "core.settings"
 env_files = [".env.template"]
 addopts = "--reuse-db"
+filterwarnings = ["error"]
 
 [project]
 name = "sppnaut"

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -5,9 +5,11 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def disable_whitenoise(settings):
-    settings.STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.StaticFilesStorage"
-    )
+    settings.STORAGES = {
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        }
+    }
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Also mark warnings as failures when running our tests so we can detect this issue earlier.

https://docs.djangoproject.com/en/4.2/releases/4.2/#custom-file-storages